### PR TITLE
Security flow with context

### DIFF
--- a/flow/flow.go
+++ b/flow/flow.go
@@ -23,8 +23,8 @@ import (
 	"github.com/ory/ladon"
 )
 
-// CleanupFn defines a function used for cleanup. Usially you would like to defer this function
-// for after the whole process is done and you need to clen up before shutting down.
+// CleanupFn defines a function used for cleanup. Usually you would like to defer this function
+// for after the whole process is done and you need to clean up before shutting down.
 type CleanupFn func()
 
 // ConfiguredSecurity holds the entities of the fully configured security. It holds

--- a/flow/flow.go
+++ b/flow/flow.go
@@ -9,6 +9,8 @@ import (
 	"log"
 	"net/url"
 
+	"github.com/Microkubes/microservice-security/tools"
+
 	"github.com/Microkubes/microservice-security/acl"
 	"github.com/Microkubes/microservice-security/auth"
 	"github.com/Microkubes/microservice-security/chain"
@@ -25,25 +27,34 @@ import (
 // for after the whole process is done and you need to clen up before shutting down.
 type CleanupFn func()
 
+// ConfiguredSecurity holds the entities of the fully configured security. It holds
+// the SecurityChain, the KeyStore, ACLManager (if configured) and optional cleanup function.
+type ConfiguredSecurity struct {
+	Chain      chain.SecurityChain
+	KeyStore   tools.KeyStore
+	ACLManager *acl.BackendLadonManager
+	Cleanup    CleanupFn
+}
+
 func newSAMLSecurity(gatewayURL string, conf *config.SAMLConfig) (chain.SecurityChainMiddleware, *samlsp.Middleware, error) {
 	keyPair, err := tls.LoadX509KeyPair(conf.CertFile, conf.KeyFile)
 	if err != nil {
-		panic(err)
+		return nil, nil, err
 	}
 
 	keyPair.Leaf, err = x509.ParseCertificate(keyPair.Certificate[0])
 	if err != nil {
-		panic(err)
+		return nil, nil, err
 	}
 
 	rootURL, err := url.Parse(fmt.Sprintf("%s", conf.RootURL))
 	if err != nil {
-		panic(err)
+		return nil, nil, err
 	}
 
 	idpMetadataURL, err := url.Parse(fmt.Sprintf("%s/saml/idp/metadata", gatewayURL))
 	if err != nil {
-		panic(err)
+		return nil, nil, err
 	}
 
 	samlSP, err := samlsp.New(samlsp.Options{
@@ -58,18 +69,31 @@ func newSAMLSecurity(gatewayURL string, conf *config.SAMLConfig) (chain.Security
 	return saml.NewSAMLSecurity(samlSP, conf), samlSP, nil
 }
 
-// NewSecurityFromConfig sets up a full secrity chain froma a given service configuration.
+// NewSecurityFromConfig sets up a full security chain from a a given service configuration.
 func NewSecurityFromConfig(cfg *config.ServiceConfig) (chain.SecurityChain, CleanupFn, error) {
+	security, err := NewConfiguredSecurityFromConfig(cfg)
+	if err != nil {
+		return nil, func() {}, err
+	}
+	return security.Chain, security.Cleanup, nil
+}
+
+// NewConfiguredSecurityFromConfig sets up a full security from a given service configuration.
+func NewConfiguredSecurityFromConfig(cfg *config.ServiceConfig) (*ConfiguredSecurity, error) {
+	configuredSecurity := &ConfiguredSecurity{}
 	securityChain := chain.NewSecurityChain()
+
+	configuredSecurity.Chain = securityChain
+
 	if cfg.Disable {
 		log.Println("WARN: Security is disabled. Please check your configuration.")
-		return securityChain, func() {}, nil
+		return configuredSecurity, nil
 	}
 
 	if cfg.IgnorePatterns != nil {
 		for _, pattern := range cfg.IgnorePatterns {
 			if err := securityChain.AddIgnorePattern(pattern); err != nil {
-				return nil, func() {}, err
+				return nil, err
 			}
 		}
 	}
@@ -88,6 +112,14 @@ func NewSecurityFromConfig(cfg *config.ServiceConfig) (chain.SecurityChain, Clea
 	cleanup := func() {
 		managerCleanup()
 		samlCleanup()
+	}
+
+	if cfg.SecurityConfig.KeysDir != "" {
+		keyStore, err := tools.NewDirKeyStore(cfg.SecurityConfig.KeysDir)
+		if err != nil {
+			return nil, err
+		}
+		configuredSecurity.KeyStore = keyStore
 	}
 
 	if cfg.SecurityConfig.JWTConfig != nil {
@@ -124,12 +156,12 @@ func NewSecurityFromConfig(cfg *config.ServiceConfig) (chain.SecurityChain, Clea
 	if cfg.SecurityConfig.SAMLConfig != nil {
 		samlMiddleware, spMiddleware, err := newSAMLSecurity(cfg.GatewayURL, cfg.SAMLConfig)
 		if err != nil {
-			return nil, cleanup, err
+			return nil, err
 		}
 
 		sc, err := saml.RegisterSP(spMiddleware, cfg.SAMLConfig)
 		if err != nil {
-			return nil, cleanup, err
+			return nil, err
 		}
 		samlCleanup = sc
 
@@ -140,7 +172,7 @@ func NewSecurityFromConfig(cfg *config.ServiceConfig) (chain.SecurityChain, Clea
 		cfg.SecurityConfig.OAuth2Config == nil &&
 		cfg.SecurityConfig.SAMLConfig == nil {
 		// No security defined
-		return securityChain, cleanup, nil
+		return configuredSecurity, nil
 
 	}
 
@@ -149,7 +181,7 @@ func NewSecurityFromConfig(cfg *config.ServiceConfig) (chain.SecurityChain, Clea
 	if cfg.ACLConfig != nil && !cfg.ACLConfig.Disable {
 		manager, mc, err := acl.NewBackendLadonManager(&cfg.DBConfig)
 		if err != nil {
-			return nil, cleanup, err
+			return nil, err
 		}
 		managerCleanup = mc
 
@@ -163,7 +195,7 @@ func NewSecurityFromConfig(cfg *config.ServiceConfig) (chain.SecurityChain, Clea
 			Subjects:    []string{"system"}, // only system
 		}, manager)
 		if err != nil {
-			panic(err)
+			return nil, err
 		}
 
 		if cfg.ACLConfig.Policies != nil {
@@ -179,25 +211,28 @@ func NewSecurityFromConfig(cfg *config.ServiceConfig) (chain.SecurityChain, Clea
 				if policy.Conditions != nil {
 					conditions, e := conditionsFromConfig(policy.Conditions)
 					if e != nil {
-						return nil, cleanup, e
+						return nil, e
 					}
 					ladonPolicy.Conditions = conditions
 				}
 				e := addOrUpdatePolicy(ladonPolicy, manager)
 				if e != nil {
-					return nil, cleanup, e
+					return nil, e
 				}
 			}
 		}
 
 		aclMiddleware, err := acl.NewACLMiddleware(manager)
 		if err != nil {
-			return nil, cleanup, err
+			return nil, err
 		}
 		securityChain.AddMiddleware(aclMiddleware)
+		configuredSecurity.ACLManager = manager
 	}
 
-	return securityChain, cleanup, nil
+	configuredSecurity.Cleanup = cleanup
+
+	return configuredSecurity, nil
 }
 
 func addOrUpdatePolicy(policy ladon.Policy, manager *acl.BackendLadonManager) error {

--- a/tools/keystore.go
+++ b/tools/keystore.go
@@ -105,6 +105,7 @@ func NewDirKeyStore(keysDir string) (KeyStore, error) {
 	return NewFileKeyStore(keysMap)
 }
 
+// hasAnySuffix checks if 'name' starts with any of the supplied suffixes.
 func hasAnySuffix(name string, suffixes ...string) *string {
 	var suffix *string
 	name = strings.ToLower(name)

--- a/tools/keystore.go
+++ b/tools/keystore.go
@@ -3,6 +3,10 @@ package tools
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
+	"path"
+
+	"strings"
 
 	jwtgo "github.com/dgrijalva/jwt-go"
 )
@@ -70,4 +74,45 @@ func NewFileKeyStore(keyFiles map[string]string) (KeyStore, error) {
 	}
 	keyStore.PrivateKey = defaultKey
 	return &keyStore, nil
+}
+
+// NewDirKeyStore returns a directory-based KeyStore implementation.
+// The keys are loaded from the directory by scanning the directory
+// for private keys.
+// The functions expects to be at least one key with name "default" defined.
+// The keys must be RSA keys and the files must be PEM.
+func NewDirKeyStore(keysDir string) (KeyStore, error) {
+	fi, err := os.Stat(keysDir)
+	if err != nil {
+		return nil, err
+	}
+	if !fi.Mode().IsDir() {
+		return nil, fmt.Errorf("directory must be provided")
+	}
+	files, err := ioutil.ReadDir(keysDir)
+	if err != nil {
+		return nil, err
+	}
+	keysMap := map[string]string{}
+	for _, file := range files {
+		if !file.IsDir() {
+			name := file.Name()
+			if suffix := hasAnySuffix(name, ".pub", ".pubk", ".pk"); suffix == nil {
+				keysMap[name] = path.Join(keysDir, name)
+			}
+		}
+	}
+	return NewFileKeyStore(keysMap)
+}
+
+func hasAnySuffix(name string, suffixes ...string) *string {
+	var suffix *string
+	name = strings.ToLower(name)
+	for _, sfx := range suffixes {
+		if strings.HasSuffix(name, sfx) {
+			suffix = &sfx
+			break
+		}
+	}
+	return suffix
 }

--- a/tools/keystore_test.go
+++ b/tools/keystore_test.go
@@ -1,0 +1,144 @@
+package tools
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+)
+
+func TestFileBasedKeyStore(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		os.RemoveAll(tmpDir)
+	}()
+	t.Log("Temp dir: ", tmpDir)
+
+	if err = generateRSAKeyPairInDir(tmpDir, "default"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err = generateRSAKeyPairInDir(tmpDir, "system"); err != nil {
+		t.Fatal(err)
+	}
+
+	keyStore, err := NewFileKeyStore(map[string]string{
+		"system":  path.Join(tmpDir, "system"),
+		"default": path.Join(tmpDir, "default"),
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	key, err := keyStore.GetPrivateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if key == nil {
+		t.Fatal("key was not defined")
+	}
+
+	key, err = keyStore.GetPrivateKeyByName("system")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if key == nil {
+		t.Fatal("key was not defined")
+	}
+}
+
+func TestDirBasedKeyStore(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		os.RemoveAll(tmpDir)
+	}()
+
+	if err = generateRSAKeyPairInDir(tmpDir, "default"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err = generateRSAKeyPairInDir(tmpDir, "system"); err != nil {
+		t.Fatal(err)
+	}
+
+	keyStore, err := NewDirKeyStore(tmpDir)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	key, err := keyStore.GetPrivateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if key == nil {
+		t.Fatal("key was not defined")
+	}
+
+	key, err = keyStore.GetPrivateKeyByName("system")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if key == nil {
+		t.Fatal("key was not defined")
+	}
+}
+
+func generateRSAKeyPairInDir(dir string, keyFileName string) error {
+	keyPair, err := generateRSAKeyPair()
+	if err != nil {
+		return err
+	}
+
+	pubKeyBytes, err := x509.MarshalPKIXPublicKey(&keyPair.PublicKey) //asn1.Marshal(keyPair.PublicKey)
+
+	if err != nil {
+		return err
+	}
+
+	pubPemKey := &pem.Block{
+		Type:  "RSA PUBLIC KEY",
+		Bytes: pubKeyBytes,
+	}
+
+	privPemKey := &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(keyPair),
+	}
+
+	pubKeyFile, err := os.Create(fmt.Sprintf("%s/%s.pub", dir, keyFileName))
+	if err != nil {
+		return err
+	}
+	privKeyFile, err := os.Create(fmt.Sprintf("%s/%s", dir, keyFileName))
+	if err != nil {
+		return err
+	}
+
+	err = pem.Encode(pubKeyFile, pubPemKey)
+	if err != nil {
+		return err
+	}
+	err = pem.Encode(privKeyFile, privPemKey)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func generateRSAKeyPair() (*rsa.PrivateKey, error) {
+	return rsa.GenerateKey(rand.Reader, 2048)
+}


### PR DESCRIPTION
Added alternative helper to create Security flow from configuration which returns ```ConfiguredSecurity``` struct that contains multiple useful objects, such as: the ```SecurityChain```, ```ACLManager```, ```KeyStore``` etc.