### PR TITLE
Keystore fix

### DIFF
--- a/flow/flow.go
+++ b/flow/flow.go
@@ -114,13 +114,13 @@ func NewConfiguredSecurityFromConfig(cfg *config.ServiceConfig) (*ConfiguredSecu
 		samlCleanup()
 	}
 
-	// if cfg.SecurityConfig.KeysDir != "" {
-	// 	keyStore, err := tools.NewDirKeyStore(cfg.SecurityConfig.KeysDir)
-	// 	if err != nil {
-	// 		return nil, err
-	// 	}
-	// 	configuredSecurity.KeyStore = keyStore
-	// }
+	if cfg.SecurityConfig.KeysDir != "" {
+		keyStore, err := tools.NewDirKeyStore(cfg.SecurityConfig.KeysDir)
+		if err != nil {
+			return nil, err
+		}
+		configuredSecurity.KeyStore = keyStore
+	}
 
 	if cfg.SecurityConfig.JWTConfig != nil {
 		jwtSpec := &goa.JWTSecurity{

--- a/tools/keystore.go
+++ b/tools/keystore.go
@@ -98,7 +98,7 @@ func NewDirKeyStore(keysDir string) (KeyStore, error) {
 	}
 	keysMap := map[string]string{}
 	for _, file := range files {
-		if file.IsRegular() {
+		if file.Mode().IsRegular() {
 			name := file.Name()
 			if suffix := hasAnySuffix(name, ".pub", ".pubk", ".pk", ".cert", ".crt", ".json", ".yaml", ".yml"); suffix == nil {
 				keysMap[name] = path.Join(keysDir, name)

--- a/tools/keystore.go
+++ b/tools/keystore.go
@@ -98,7 +98,7 @@ func NewDirKeyStore(keysDir string) (KeyStore, error) {
 	}
 	keysMap := map[string]string{}
 	for _, file := range files {
-		if !file.IsDir() {
+		if file.IsRegular() {
 			name := file.Name()
 			if suffix := hasAnySuffix(name, ".pub", ".pubk", ".pk", ".cert", ".crt", ".json", ".yaml", ".yml"); suffix == nil {
 				keysMap[name] = path.Join(keysDir, name)

--- a/tools/keystore.go
+++ b/tools/keystore.go
@@ -61,9 +61,8 @@ func NewFileKeyStore(keyFiles map[string]string) (KeyStore, error) {
 	for keyName, keyFile := range keyFiles {
 		keyBytes, err := ioutil.ReadFile(keyFile)
 		if err != nil {
-			log.Print("Error")
-			log.Println(err)
-			// return nil, err
+			log.Println("Error reading key: ", err)
+			log.Println("Continuing on next key")
 			continue
 		}
 		privKey, err := jwtgo.ParseRSAPrivateKeyFromPEM(keyBytes)

--- a/tools/keystore.go
+++ b/tools/keystore.go
@@ -61,7 +61,10 @@ func NewFileKeyStore(keyFiles map[string]string) (KeyStore, error) {
 	for keyName, keyFile := range keyFiles {
 		keyBytes, err := ioutil.ReadFile(keyFile)
 		if err != nil {
-			return nil, err
+			log.Print("Error")
+			log.Println(err)
+			// return nil, err
+			continue
 		}
 		privKey, err := jwtgo.ParseRSAPrivateKeyFromPEM(keyBytes)
 		if err != nil {

--- a/tools/keystore.go
+++ b/tools/keystore.go
@@ -98,7 +98,7 @@ func NewDirKeyStore(keysDir string) (KeyStore, error) {
 	}
 	keysMap := map[string]string{}
 	for _, file := range files {
-		if file.Mode().IsRegular() {
+		if !file.Mode().IsDir() {
 			name := file.Name()
 			if suffix := hasAnySuffix(name, ".pub", ".pubk", ".pk", ".cert", ".crt", ".json", ".yaml", ".yml"); suffix == nil {
 				keysMap[name] = path.Join(keysDir, name)


### PR DESCRIPTION
Keystore creating is now enabled again.
Fixes for reading links in `./keys` folder are below.

On a kubernetes deployment keys were created as such:
```
/ # ls -la run/secrets/micro-org/
total 4
drwxrwxrwt    3 root     root           240 May  7 18:57 .
drwxr-xr-x    4 root     root          4096 May  7 18:57 ..
drwxr-xr-x    2 root     root           200 May  7 18:57 ..2019_05_07_18_57_32.534100360
lrwxrwxrwx    1 root     root            31 May  7 18:57 ..data -> ..2019_05_07_18_57_32.534100360
lrwxrwxrwx    1 root     root            14 May  7 18:57 default -> ..data/default
lrwxrwxrwx    1 root     root            18 May  7 18:57 default.pub -> ..data/default.pub
lrwxrwxrwx    1 root     root            18 May  7 18:57 private.pem -> ..data/private.pem
lrwxrwxrwx    1 root     root            17 May  7 18:57 public.pub -> ..data/public.pub
lrwxrwxrwx    1 root     root            19 May  7 18:57 service.cert -> ..data/service.cert
lrwxrwxrwx    1 root     root            18 May  7 18:57 service.key -> ..data/service.key
lrwxrwxrwx    1 root     root            13 May  7 18:57 system -> ..data/system
lrwxrwxrwx    1 root     root            17 May  7 18:57 system.pub -> ..data/system.pub
```

In this case `..data` passed the checks as a file which caused an error to be returned when creating a new FileKeyStore.

The changes in this PR print the error but don't return, instead they continue parsing the rest of the keys. 